### PR TITLE
Update mirador_rails dependency…

### DIFF
--- a/spotlight_mirador.gemspec
+++ b/spotlight_mirador.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'mirador_rails'
+  spec.add_dependency 'mirador_rails', '>= 0.3.3'
 
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
… to ensure that 0.3.3 or higher is loaded.

<img width="769" alt="spotlight_mirador" src="https://cloud.githubusercontent.com/assets/96776/24228958/5e3adc54-0f34-11e7-94bb-3cf8baf0c311.png">
